### PR TITLE
missing statuses are not errors

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -34,7 +34,7 @@ func (b *Builder) GetStatus(sha string) (string, error) {
 	_, _, statusPath := b.getPaths(sha)
 	contents, err := ioutil.ReadFile(statusPath)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return string(contents), nil
 }

--- a/main.go
+++ b/main.go
@@ -109,10 +109,11 @@ func handleRemoteChanges(changes <-chan *repo.BranchEvent, pub *publisher.Publis
 		fmt.Printf("detected a remote being updated %v.\n", c.SHA)
 		go func(sha string) {
 			err := pub.Publish(sha)
-			switch err {
-			case nil:
+			if os.IsNotExist(err) {
+				return
+			} else if err == nil {
 				fmt.Println(aurora.Green("sucessfully published build results."))
-			default:
+			} else {
 				fmt.Printf("%v %v\n", aurora.Red("unable to publish results:"), err)
 			}
 		}(c.SHA)


### PR DESCRIPTION
When a branch is updated as part of `git fetch` or the like, there will never be a local build to upload. so if the build file is missing, then we don't need to try and upload anything.