### PR TITLE
fix the regex to summarize failures

### DIFF
--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 )
 
-var failMatch = regexp.MustCompile("(?im)(.*fail[^\n]*\n[^\n]+)")
+var failMatch = regexp.MustCompile("(?i)(.*fail.*)")
 
 type Publisher struct {
 	storage Storage
@@ -155,6 +156,7 @@ func addFailureMarkdown(body string) string {
 	return fmt.Sprintf(`# FAILED
 tldr;
 %v
+# grep 'fail'
 %v
 %v
 
@@ -163,7 +165,7 @@ total time %v seconds
 
 %v
 %v
-%v`, "```", shortBody, "```", 1, "```", body, "```")
+%v`, "```", strings.Join(shortBody, "\n"), "```", 1, "```", body, "```")
 }
 
 func addErrorMarkdown(body string) string {

--- a/internal/publisher/publisher_test.go
+++ b/internal/publisher/publisher_test.go
@@ -1,0 +1,16 @@
+package publisher
+
+import (
+	"testing"
+)
+
+func TestSummaryRegex(t *testing.T) {
+	short := failMatch.FindAllString("failure: something went wrong", -1)
+	if len(short) == 0 || short[0] == "" {
+		t.Fatalf("nothing was matched on a single line")
+	}
+	short = failMatch.FindAllString("fAiLure: something went wrong", -1)
+	if len(short) == 0 || short[0] == "" {
+		t.Fatalf("case insensitive failed")
+	}
+}


### PR DESCRIPTION
this fixes the regex to grab all the lines that contain `fail` and use them in a summary at the top of the file. The full output is still in the file.