### PR TITLE
skip builds that have no changed files

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -16,6 +16,7 @@ import (
 )
 
 var ErrNotFound = fmt.Errorf("the status was not found")
+var ErrNoChanges = fmt.Errorf("no changes were detected")
 var ErrNoMakefile = fmt.Errorf("no makefile was found")
 
 type Builder struct {
@@ -135,6 +136,10 @@ func (b *Builder) Build(sha string) error {
 		}
 	}
 
+	if len(files) == 0 {
+		return ErrNoChanges
+	}
+
 	lcp := calculateLCP(files)
 	lcp = filepath.Clean(lcp)
 
@@ -155,7 +160,7 @@ func (b *Builder) Build(sha string) error {
 	if len(b.command) > 1 {
 		args = b.command[1:]
 	}
-	fmt.Printf("running %s\n", b.command)
+	fmt.Printf("running %v %s\n", testPath, b.command)
 	command := exec.Command(c, args...)
 	command.Dir = testPath
 	out, origErr := command.CombinedOutput()

--- a/main.go
+++ b/main.go
@@ -67,6 +67,9 @@ func singleRun(flags *flags, arg string) {
 	case builder.ErrNoMakefile:
 		fmt.Println("no Makefile was found skipping tests.")
 		os.Exit(1)
+	case builder.ErrNoChanges:
+		fmt.Println(aurora.Yellow("no changes were detected."))
+		os.Exit(0)
 	default:
 		fmt.Printf("%v %v\n", aurora.Red("build Failed"), err)
 	}
@@ -144,6 +147,8 @@ func handleLocalChanges(changes <-chan *repo.BranchEvent, build *builder.Builder
 			fmt.Println(aurora.Green("build was sucessful!"))
 		case builder.ErrNoMakefile:
 			fmt.Println("no Makefile was found skipping tests.")
+		case builder.ErrNoChanges:
+			fmt.Println(aurora.Yellow("no changes were detected."))
 		default:
 			fmt.Println(aurora.Red("build Failed."))
 		}


### PR DESCRIPTION
builds that have no files changed, may not build correctly as the `Makefile` falls back to the root of the repo.