### PR TITLE
Dbarney/configurable origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Because this is designed to be run on the same server, it can take advantage of 
 prof # runs in CI/CD mode. watches local branches for changes and runs makefile targets
 prof {branch|tag|commit} # runs a single build and uploads the results.
 prof --comand 'make build' # override the command used to build
+prof --origin 'git@github.com:dbarney/professor' # pull changes from this remote and don't try and use the current folder as a source for changes.
 ```
 
 ### Example builds
@@ -24,6 +25,7 @@ A lot of other settings currently aren't exposed and are set by reading the git 
 
 ### future ideas?
 ```
-prof --branch origin/master # only build when this ref changes
+prof --limit-to-users 'dbarney,john' # ony run commits by these users
+prof --build remote/origin # build refs matching this pattern 
 prof --command 'make build-production' '--release './bin' # maybe create a github release? tag based maybe?
 ```

--- a/config.go
+++ b/config.go
@@ -9,14 +9,15 @@ import (
 	"strings"
 
 	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport/http"
 )
 
 type config struct {
 	topLevel    string
 	testPath    string
-	makefile    string
 	buildPath   string
 	workingPath string
+	gitFolder   string
 
 	token string
 	host  string
@@ -27,46 +28,86 @@ type config struct {
 var urlMatch = regexp.MustCompile("git@([^:]+):([^/]+)/([^.]+)[.]git")
 var pathMatch = regexp.MustCompile("([^/]+)/(.+)")
 
-func getConfig() (*config, error) {
-	// find the top level folder
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return nil, err
-	}
+func getConfig(origin string) (*config, error) {
+	c := &config{}
 
-	topLevel := strings.TrimSpace(string(out))
-
-	token := os.Getenv("PROFESSOR_TOKEN")
-	if token == "" {
+	c.token = os.Getenv("PROFESSOR_TOKEN")
+	if c.token == "" {
 		return nil, fmt.Errorf("PROFESSOR_TOKEN was empty")
 	}
+	if strings.HasPrefix(origin, "git@") || strings.HasPrefix(origin, "https://") {
+		parts := urlMatch.FindStringSubmatch(origin)
+		if len(parts) != 4 {
+			panic(fmt.Sprintf("remote didn't match %v", parts))
+		}
 
-	base, err := git.PlainOpen(topLevel)
-	if err != nil {
-		return nil, err
+		c.host = parts[1]
+		c.owner = parts[2]
+		c.name = parts[3]
+		c.topLevel = "./"
+		c.gitFolder = c.topLevel
+
+		// this really needs to be a better check.
+		if _, err := os.Stat("./HEAD"); err != nil {
+			// uses https cloning because we have a token already.
+			// don't need an ssh key this way
+			url := fmt.Sprintf("https://%v/%v/%v.git", c.host, c.owner, c.name)
+			// a remote that needs to be cloned down
+			_, err := git.PlainClone(c.topLevel, true, &git.CloneOptions{
+				URL: url,
+				Auth: &http.BasicAuth{
+					Username: "dbarney",
+					Password: c.token,
+				},
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		c.testPath = path.Join(c.topLevel)
+		c.buildPath = path.Join(c.topLevel, "professor", "builds")
+		c.workingPath = path.Join(c.topLevel, "professor")
+
+	} else {
+		// try to discover from the current working directory
+		// find the top level folder
+		command := exec.Command("git", "rev-parse", "--show-toplevel")
+		if origin != "" {
+			// if origin isn't nil, then lets use it as the path to check
+			// for a git repo
+			command.Dir = origin
+		}
+		out, err := command.Output()
+		if err != nil {
+			return nil, err
+		}
+		c.topLevel = strings.TrimSpace(string(out))
+
+		c.gitFolder = path.Join(c.topLevel, ".git")
+		c.workingPath = path.Join(c.gitFolder, "professor")
+		c.testPath = path.Join(c.workingPath, "working")
+		c.buildPath = path.Join(c.workingPath, "builds")
+
+		base, err := git.PlainOpen(c.topLevel)
+		if err != nil {
+			return nil, err
+		}
+
+		origin, err := base.Remote("origin")
+		if err != nil {
+			return nil, err
+		}
+
+		remote := origin.Config().URLs[0]
+		parts := urlMatch.FindStringSubmatch(remote)
+		if len(parts) != 4 {
+			panic("remote didn't match")
+		}
+
+		c.host = parts[1]
+		c.owner = parts[2]
+		c.name = parts[3]
 	}
-
-	origin, err := base.Remote("origin")
-	if err != nil {
-		return nil, err
-	}
-
-	remote := origin.Config().URLs[0]
-	parts := urlMatch.FindStringSubmatch(remote)
-	if len(parts) != 4 {
-		panic("remote didn't match")
-	}
-
-	return &config{
-		topLevel:    topLevel,
-		testPath:    path.Join(topLevel, ".git", "professor", "working"),
-		makefile:    path.Join(topLevel, ".git", "professor", "working", "Makefile"),
-		buildPath:   path.Join(topLevel, ".git", "professor", "builds"),
-		workingPath: path.Join(topLevel, ".git", "professor"),
-
-		token: token,
-		host:  parts[1],
-		owner: parts[2],
-		name:  parts[3],
-	}, nil
+	return c, nil
 }

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -25,17 +25,15 @@ type Builder struct {
 	original  *git.Repository
 	clone     *git.Repository
 	command   []string
-	makefile  string
 	buildPath string
 	testPath  string
 }
 
-func NewBuilder(original, clone *git.Repository, command, makefile, buildPath, testPath string) *Builder {
+func NewBuilder(original, clone *git.Repository, command, buildPath, testPath string) *Builder {
 	return &Builder{
 		original:  original,
 		clone:     clone,
 		command:   splitString(command),
-		makefile:  makefile,
 		buildPath: buildPath,
 		testPath:  testPath,
 	}

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -31,13 +31,13 @@ func New(path string) *Local {
 }
 
 func (l *Local) WatchRemoteBranches() (<-chan *BranchEvent, error) {
-	return l.watch(path.Join(l.path, ".git", "refs", "remotes", "origin"))
+	return l.watch(path.Join(l.path, "refs", "remotes", "origin"))
 }
 
 // Watch branch returns a channel that reports if something changes
 // with a local branch
 func (l *Local) WatchLocalBranches() (<-chan *BranchEvent, error) {
-	return l.watch(path.Join(l.path, ".git", "refs", "heads"))
+	return l.watch(path.Join(l.path, "refs", "heads"))
 }
 
 func (l *Local) watch(path string) (<-chan *BranchEvent, error) {
@@ -48,7 +48,13 @@ func (l *Local) watch(path string) (<-chan *BranchEvent, error) {
 	l.watchers = append(l.watchers, watcher)
 
 	err = watcher.Add(path)
-	filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+	if err != nil {
+		return nil, err
+	}
+	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
this allows the origin to be configured through a command line argument.

This is an important change as it allows professor to run on a bare repository, one without a working directory. This should allow professor to run directly on repositories that are meant for collaboration.