### PR TITLE
add in auto-publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ prof # runs in CI/CD mode. watches local branches for changes and runs makefile 
 prof {branch|tag|commit} # runs a single build and uploads the results.
 prof --comand 'make build' # override the command used to build
 prof --origin 'git@github.com:dbarney/professor' # pull changes from this remote and don't try and use the current folder as a source for changes.
+prof --auto-publish # don't wait for a remote to be updated, after the build works, upload the result
 ```
 
 ### Example builds


### PR DESCRIPTION
This allows results of builds to happen without waiting on local files to change. This is part of what is needed to allow a build to happen when a remote gets updated, aka build-server like behavior.