### PR TITLE
allow builds to only build certain refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ prof {branch|tag|commit} # runs a single build and uploads the results.
 prof --comand 'make build' # override the command used to build
 prof --origin 'git@github.com:dbarney/professor' # pull changes from this remote and don't try and use the current folder as a source for changes.
 prof --auto-publish # don't wait for a remote to be updated, after the build works, upload the result
+prof --build remote/origin # build refs matching this pattern
 ```
 
 ### Example builds
@@ -27,6 +28,5 @@ A lot of other settings currently aren't exposed and are set by reading the git 
 ### future ideas?
 ```
 prof --limit-to-users 'dbarney,john' # ony run commits by these users
-prof --build remote/origin # build refs matching this pattern 
 prof --command 'make build-production' '--release './bin' # maybe create a github release? tag based maybe?
 ```

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -36,8 +36,8 @@ func (l *Local) WatchRemoteBranches() (<-chan *BranchEvent, error) {
 
 // Watch branch returns a channel that reports if something changes
 // with a local branch
-func (l *Local) WatchLocalBranches() (<-chan *BranchEvent, error) {
-	return l.watch(path.Join(l.path, "refs", "heads"))
+func (l *Local) WatchLocalBranches(refs string) (<-chan *BranchEvent, error) {
+	return l.watch(path.Join(l.path, "refs", refs))
 }
 
 func (l *Local) watch(path string) (<-chan *BranchEvent, error) {

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ type flags struct {
 	command     string
 	origin      string
 	autoPublish bool
+	build       string
 }
 
 func main() {
@@ -25,6 +26,7 @@ func main() {
 	flag.StringVar(&flags.command, "command", "make test", "the command that should be run")
 	flag.StringVar(&flags.origin, "origin", "", "the remote to use as the origin, defaults to the local directory")
 	flag.BoolVar(&flags.autoPublish, "auto-publish", false, "trigger publishing when builds finish")
+	flag.StringVar(&flags.build, "build", "heads", "the refs to monitor to trigger builds")
 	flag.Parse()
 	args := flag.Args()
 	if len(args) == 0 {
@@ -100,7 +102,7 @@ func headlessRun(flags *flags) {
 	}
 	// watch for changes on local branches and remote branches
 	repository := repo.New(config.gitFolder)
-	local, err := repository.WatchLocalBranches()
+	local, err := repository.WatchLocalBranches(flags.build)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This is a small change, but it really sets up how all build filtering is done.

By default the local `heads` are monitored, but this can now be changed to whatever is wanted.
Setting to `remotes/origin` will trigger a build when anything is pushed to the origin.
By changing how you name branches, even more customized builds can occur.
if you branches match the `$TEAM/$USER/branch` pattern, you can set up individual build servers, or even team build servers, just by isolating builds to exactly what needs to be watched.